### PR TITLE
Upgrade dependencies versions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,12 @@
 PATH
   remote: .
   specs:
-    swagalicious (0.1.0)
-      faraday (~> 1.0.1)
+    swagalicious (0.2.0)
+      faraday (~> 1.3.0)
       json-schema (~> 2.8.1)
-      oj (~> 3.10.14)
+      oj (~> 3.11.0)
       rack-test (~> 1.1.0)
+      rspec (~> 3.10.0)
 
 GEM
   remote: https://rubygems.org/
@@ -13,30 +14,34 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     diff-lcs (1.4.4)
-    faraday (1.0.1)
+    faraday (1.3.0)
+      faraday-net_http (~> 1.0)
       multipart-post (>= 1.2, < 3)
+      ruby2_keywords
+    faraday-net_http (1.0.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
     multipart-post (2.1.1)
-    oj (3.10.14)
+    oj (3.11.0)
     public_suffix (4.0.6)
     rack (2.2.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rake (12.3.3)
-    rspec (3.9.0)
-      rspec-core (~> 3.9.0)
-      rspec-expectations (~> 3.9.0)
-      rspec-mocks (~> 3.9.0)
-    rspec-core (3.9.2)
-      rspec-support (~> 3.9.3)
-    rspec-expectations (3.9.2)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-core (3.10.1)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.9.0)
-    rspec-mocks (3.9.1)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.9.0)
-    rspec-support (3.9.3)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.1)
+    ruby2_keywords (0.0.4)
 
 PLATFORMS
   ruby
@@ -47,4 +52,4 @@ DEPENDENCIES
   swagalicious!
 
 BUNDLED WITH
-   2.1.2
+   2.2.6

--- a/lib/swagalicious/version.rb
+++ b/lib/swagalicious/version.rb
@@ -1,3 +1,3 @@
 class Swagalicious
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end

--- a/swagalicious.gemspec
+++ b/swagalicious.gemspec
@@ -24,9 +24,9 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "faraday",     "~> 1.0.1"
+  spec.add_dependency "faraday",     "~> 1.3.0"
   spec.add_dependency "json-schema", "~> 2.8.1"
-  spec.add_dependency "oj",          "~> 3.10.14"
+  spec.add_dependency "oj",          "~> 3.11.0"
   spec.add_dependency "rack-test",   "~> 1.1.0"
-  spec.add_dependency "rspec",       "~> 3.9.0"
+  spec.add_dependency "rspec",       "~> 3.10.0"
 end


### PR DESCRIPTION
This PR updates dependency versions for `faraday`, `oj` and `rspec` use the latest version of each them